### PR TITLE
Add podman support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/piwigo-data/
+/piwigo-data
+/podman-quadlet/piwigo-data
 /.env

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An alpine based container to easily deploy piwigo !
 
+Check the [podman README](./podman-quadlet/README.md) if you would rather use podman.
+
 ## Usage
 
 ### Starting the container

--- a/podman-quadlet/README.md
+++ b/podman-quadlet/README.md
@@ -65,7 +65,7 @@ sudo systemctl start piwigo.service
 
 ### Diagnosing errors 
 
-Access the systemd journal `journalctl --user -eu piwigo.service`, most common errors are permision issues.  
+Access the systemd journal `sudo journalctl -eu piwigo.service`, most common errors are permision issues.  
 Ensure that your volume is in a valid location and has read and write permisions.
 
 ### Documentation 

--- a/podman-quadlet/README.md
+++ b/podman-quadlet/README.md
@@ -1,0 +1,2 @@
+# Piwigo podman (Quadlet)
+

--- a/podman-quadlet/README.md
+++ b/podman-quadlet/README.md
@@ -34,8 +34,8 @@ Edit `piwigo.container` :
 
 ### Changing bind-mounts
 
-Bind mounts are links between the host filesystem and the containers.
-System placeholder are valid in quadlets, `%h` is match the container user home (`/root/`)
+Bind mounts are links between the host filesystem and the containers.  
+Systemd placeholder are valid in quadlets, `%h` is match the container user home (`/root/`) see [the documentation](#documentation)
 
 Edit `piwigo.container` :
 
@@ -65,10 +65,10 @@ sudo systemctl start piwigo.service
 
 ### Diagnosing errors 
 
-Access the systemd journal `journalctl --user -eu piwigo.service`, most common errors are permision issues.
+Access the systemd journal `journalctl --user -eu piwigo.service`, most common errors are permision issues.  
 Ensure that your volume is in a valid location and has read and write permisions.
 
-### Podman documenation
+### Documentation 
 
 - [Quadlet unit documentation](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)
 - [Volume documentation](https://docs.podman.io/en/v4.4/markdown/options/volume.html)

--- a/podman-quadlet/README.md
+++ b/podman-quadlet/README.md
@@ -1,2 +1,75 @@
 # Piwigo podman (Quadlet)
 
+## Requirements
+
+- systemd
+- podman
+
+## Usage
+
+Create `/etc/containers/systemd/piwigo/` and copy each quadlet units files in it.
+
+```
+/etc/containers/systemd/piwigo/
+    ├── piwigo-db.container
+    ├── piwigo.container
+    └── piwigo.network
+```
+
+Reload systemd units and start the service :
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl start piwigo.service
+``` 
+
+### Changing the exposed port :
+
+Edit `piwigo.container` :
+
+```diff
+- PublishPort=8080:80
++ PublishPort=12345:80
+```
+
+### Changing bind-mounts
+
+Bind mounts are links between the host filesystem and the containers.
+System placeholder are valid in quadlets, `%h` is match the container user home (`/root/`)
+
+Edit `piwigo.container` :
+
+```diff
+- Volume=./piwigo-data/piwigo:/var/www/html/piwigo:z
+- Volume=./piwigo-data/scripts:/usr/local/bin/scripts:z
++ Volume=%h/PiwigoPod/piwigo:/var/www/html/piwigo:z
++ Volume=%h/PiwigoPod/scripts:/usr/local/bin/scripts:z
+```
+
+And edit `piwigo-db.container` :
+
+```diff
+- Volume=./piwigo-data/mysql:/var/lib/mysql:z
++ Volume=%h/PiwigoPod/mysql:/var/lib/mysql:z
+```
+
+### Updating 
+
+Stop and restart your containers, podman should pull an updated image automatically.
+
+```sh
+sudo systemctl stop piwigo.service piwigo-db.service
+sudo systemctl daemon-reload
+sudo systemctl start piwigo.service
+```
+
+### Diagnosing errors 
+
+Access the systemd journal `journalctl --user -eu piwigo.service`, most common errors are permision issues.
+Ensure that your volume is in a valid location and has read and write permisions.
+
+### Podman documenation
+
+- [Quadlet unit documentation](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)
+- [Volume documentation](https://docs.podman.io/en/v4.4/markdown/options/volume.html)
+- [System unit placeholder table](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Specifiers)

--- a/podman-quadlet/piwigo-db.container
+++ b/podman-quadlet/piwigo-db.container
@@ -1,4 +1,4 @@
-# piwigo-db.container
+# Piwigo database container
 [Container]
 Environment=MARIADB_RANDOM_ROOT_PASSWORD=true MARIADB_USER=piwigodb_user MARIADB_DATABASE=piwigodb MARIADB_PASSWORD=PASSWORD
 Image=docker.io/library/mariadb:lts

--- a/podman-quadlet/piwigo-db.container
+++ b/podman-quadlet/piwigo-db.container
@@ -1,0 +1,12 @@
+# piwigo-db.container
+[Container]
+Environment=MARIADB_RANDOM_ROOT_PASSWORD=true MARIADB_USER=piwigodb_user MARIADB_DATABASE=piwigodb MARIADB_PASSWORD=PASSWORD
+Image=docker.io/library/mariadb:lts
+Network=piwigo.network
+Volume=./piwigo-data/mysql:/var/lib/mysql:z
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/podman-quadlet/piwigo.container
+++ b/podman-quadlet/piwigo.container
@@ -1,0 +1,14 @@
+# piwigo.container
+[Unit]
+Requires=piwigo-db.service
+After=piwigo-db.service
+
+[Container]
+Image=docker.io/rushlana/piwigo-test:latest
+Network=piwigo.network
+PublishPort=8080:80
+Volume=./piwigo-data/piwigo:/var/www/html/piwigo:z
+Volume=./piwigo-data/scripts:/usr/local/bin/scripts:z
+
+[Install]
+WantedBy=multi-user.target

--- a/podman-quadlet/piwigo.container
+++ b/podman-quadlet/piwigo.container
@@ -1,10 +1,10 @@
-# piwigo.container
+# Piwigo NGINX PHP-FPM container
 [Unit]
 Requires=piwigo-db.service
 After=piwigo-db.service
 
 [Container]
-Image=docker.io/rushlana/piwigo-test:latest
+Image=ghcr.io/piwigo/piwigo:latest
 Network=piwigo.network
 PublishPort=8080:80
 Volume=./piwigo-data/piwigo:/var/www/html/piwigo:z

--- a/podman-quadlet/piwigo.network
+++ b/podman-quadlet/piwigo.network
@@ -1,0 +1,2 @@
+# piwigo.network
+[Network]

--- a/podman-quadlet/piwigo.network
+++ b/podman-quadlet/piwigo.network
@@ -1,2 +1,2 @@
-# piwigo.network
+# Piwigo Network
 [Network]


### PR DESCRIPTION
Adding support for podman quadlets ( systemd managed podman containers ).

Ideally we should support rootless containers.

- [x] Create basic configuration `.container` files to match the `compose.yml`
- [ ] Add relevant documentation
- [ ] See if using a `.volume` is a good idea
- [x] Test containers in apparmor and SeLinux environment