### PR TITLE
Add healthcheck

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,8 @@ services:
     ports:
       - ${piwigo_port}:80
     depends_on:
-      - piwigo-db
+      piwigo-db:
+        condition: service_healthy
     volumes:
       - ./piwigo-data/piwigo:/var/www/html/piwigo/
       - ./piwigo-data/scripts:/usr/local/bin/scripts/
@@ -29,6 +30,12 @@ services:
       # Defined in .env
       - MARIADB_PASSWORD=${db_user_password} 
       - TZ=${timezone}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - piwigo-network
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,12 @@ services:
       - TZ=${timezone}
       - PIWIGO_UID=${PIWIGO_UID}
       - PIWIGO_GID=${PIWIGO_GID}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:80/index.php || exit 1"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     networks:
       - piwigo-network
     ports:
@@ -31,7 +37,7 @@ services:
       - MARIADB_PASSWORD=${db_user_password} 
       - TZ=${timezone}
     healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      test: ["CMD-SHELL", "healthcheck.sh --connect --innodb_initialized"]
       start_period: 10s
       interval: 10s
       timeout: 5s


### PR DESCRIPTION
This adds an healthcheck to the db container and ensure the piwigo container does not start before the db.

Using configuration from documentation https://mariadb.com/docs/server/server-management/automated-mariadb-deployment-and-administration/docker-and-mariadb/using-healthcheck-sh

And a basic healthcheck to the PHP server